### PR TITLE
DO NOT ACCEPT YET: Adds tweet length to generator window

### DIFF
--- a/assets/tinymce/js/tinymce-bctt.js
+++ b/assets/tinymce/js/tinymce-bctt.js
@@ -15,24 +15,57 @@
 						{
 							type: 'textbox',
 							name: 'tweet',
+							id: 'bctt-tweet-textbox',
 							label: editor.getLang( 'bctt.tweetableQuote', 'Tweetable Quote' ),
 							multiline : true,
-							minHeight : 60
+							minHeight : 60,
+							onkeyup: function() { 
+								var tweetLength = jQuery( '#bctt-tweet-textbox' ).val().length;
+								tweetLength += 24; // Character count of URL plus space
+								if ( 'true' == jQuery( '#bctt-viamark-checkbox' ).attr( 'aria-checked' ) ) {
+									tweetLength += jQuery( '#bctt-username-textbox' ).val().length + 6; // Username count plus space & 'via'
+								}
+								jQuery( '#bctt-text-length p span' ).html( tweetLength );
+							}
 						},
 						{
 							type: 'checkbox',
 							checked: true,
 							name: 'viamark',
+							id: 'bctt-viamark-checkbox',
 							value: true,
-							text: editor.getLang( 'bctt.viaExplainer', 'Add the username below to this tweet'),
+							text: editor.getLang( 'bctt.viaExplainer', 'Add the username below to this tweet' ),
 							label: editor.getLang( 'bctt.viaPrompt', 'Include "via"?'),
+							onclick: function() { 
+								var tweetLength = jQuery( '#bctt-tweet-textbox' ).val().length;
+								tweetLength += 24; // Character count of URL
+								if ( 'true' == jQuery( '#bctt-viamark-checkbox' ).attr( 'aria-checked' ) ) {
+									tweetLength += jQuery( '#bctt-username-textbox' ).val().length + 6; // Username count plus space & 'via'
+								}
+								jQuery( '#bctt-text-length p span' ).html( tweetLength );
+							}
 						},
 						{
 							type: 'textbox',
 							name: 'username',
-							label: editor.getLang( 'bctt.usernameExplainer', 'Which Twitter username?'),
+							id: 'bctt-username-textbox',
+							label: editor.getLang( 'bctt.usernameExplainer', 'Which Twitter username?' ),
 							multiline: false,
-							value: editor.getLang( 'bctt.userPrePopulated', ''),
+							value: editor.getLang( 'bctt.userPrePopulated', '' ),
+							onkeyup: function() { 
+								var tweetLength = jQuery( '#bctt-tweet-textbox' ).val().length;
+								tweetLength += 24; // Character count of URL
+								if ( 'true' == jQuery( '#bctt-viamark-checkbox' ).attr( 'aria-checked' ) ) {
+									tweetLength += jQuery( '#bctt-username-textbox' ).val().length + 6; // Username count plus space & 'via'
+								}
+								jQuery( '#bctt-text-length p span' ).html( tweetLength );
+							}
+						},
+						{
+							type: 'container',
+							name: 'container',
+							id: 'bctt-text-length',
+							html: '<p>' + editor.getLang( 'bctt.totalLengthExplainer', 'Total Length:' ) + ' <span></span></p>'
 						}
 					],
 					width: 800,


### PR DESCRIPTION
Adds functions bound to key up and click on the different fields that calculate tweet length and then adds to the bottom of generator window.

Right now, the anonymous function is duplicated for each field. Need to find a better way to define the function and re-use in the same context. I'll have to ponder this over for a little bit.

Spot-checked a few of my tweets and works so far. More testing still needed.

How should we word/design the "total length" field at the bottom? Right now it just says "Total Length: x" where x is the character count.