### PR TITLE
Use post title as Twitter message when tweet attribute is left empty.

### DIFF
--- a/better-click-to-tweet.php
+++ b/better-click-to-tweet.php
@@ -130,7 +130,7 @@ function bctt_shortcode( $atts ) {
 
 	}
 
-	$text = $atts['tweet'];
+	$text = empty($atts['tweet']) ? get_the_title() : $atts['tweet'];
 
 	if ( filter_var( $atts['url'], FILTER_VALIDATE_URL ) ) {
 


### PR DESCRIPTION
For a lazy person like me, who doesn't always want to type in a Twitter message, accept the `[bctt]` shortcode without a tweet attribute to automatically use the post title as Twitter message.