### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/includes/updater/license-page.php
+++ b/includes/updater/license-page.php
@@ -120,7 +120,7 @@ function bctt_register_license_option() {
 	$args = array(
 		'type' => 'string',
 		'sanitize_callback' => 'sanitize_text_field',
-		'default' => NULL,
+		'default' => null,
 	);
 	foreach ( $active_plugins as $addons ) {
 		$shortname  = bctt_addon_slug( bctt_addon_shortname( $addons['Name'] ) );


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!