### PR TITLE
Escape $_SERVER['REQUEST_URI']

### DIFF
--- a/includes/views/welcome/_welcome.php
+++ b/includes/views/welcome/_welcome.php
@@ -22,7 +22,7 @@
 
         <form 
             id="bctt-set-handle" 
-            action="<?php echo $_SERVER['REQUEST_URI']; ?>" 
+            action="<?php echo esc_attr($_SERVER['REQUEST_URI']); ?>" 
             method="post"
             class="text-center flex flex-col flex-no-wrap mt-8">
 


### PR DESCRIPTION
In limited circumstances, `$_SERVER['REQUEST_URI']` can be considered a dangerous source of user input, and as such, can cause reflected XSS. Normally, browsers URL-encode the path before sending the request to the server. However, reverse proxies sometimes decode the path before forwarding it to the server. A request such as `http://wpdistillery.vm/wp-admin/index.php/abc%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E?page=bctt-welcome&step=bctt-setup` with an nginx configuration such as 
```
        server{
                listen 80;
                server_name wpdistillery.vm;
                location / {
                proxy_pass http://192.168.33.10/;
                }

        }
```
 will lead to reflected cross-site scripting. If an administrator were to visit a malicious URL provided by an attacker, the attacker would have the ability to perform most administrative actions and read most data available to the administrator.