### PR TITLE
Only load BCTT assets where they are needed [Performance]

### DIFF
--- a/assets/block/init.php
+++ b/assets/block/init.php
@@ -87,6 +87,6 @@ function bctt_block_callback( $attributes ) {
 		'nofollow' => $nofollow ? 'yes' : 'no',
 		'prompt'   => $prompt
 	), $attributes );
-
+    bctt_scripts();
 	return bctt_shortcode( $shortcode_attributes );
 }

--- a/better-click-to-tweet.php
+++ b/better-click-to-tweet.php
@@ -246,7 +246,7 @@ function bctt_scripts() {
 }
 
 
-add_action( 'wp_enqueue_scripts', 'bctt_scripts', 10 );
+//add_action( 'wp_enqueue_scripts', 'bctt_scripts', 10 );
 
 /**
  * Check if default stylesheet must not be enqueued


### PR DESCRIPTION
Moving styles and scripts enqueue to the register_block callback function allows to enqueue assets conditionally -- they will be loaded on the pages where the block is used, and won't be loaded where the block is not. Should be working the same with any theme, whether it's FSE/uses Gutenberg/Classic editor etc.